### PR TITLE
Issue #1: 日本語ロケールとタイムゾーン(Tokyo)を設定 

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -11,13 +11,13 @@ module KouyouseiChecker
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 8.0
 
-       # === ここから追記（ISSUE #1 日本語化 & タイムゾーン）===
+    # === ここから追記（ISSUE #1 日本語化 & タイムゾーン）===
     config.i18n.default_locale = :ja
-    config.i18n.available_locales = [:ja, :en]  # 必須ではないが明示しておくと安心
-    config.time_zone = 'Tokyo'
+    config.i18n.available_locales = [ :ja, :en ]  # 必須ではないが明示しておくと安心
+    config.time_zone = "Tokyo"
     config.active_record.default_timezone = :local  # DBの時刻もJSTにしたい場合
-       # （UTCのままで良ければ↑行は削除）
-       # === ここまで追記 ===
+    # （UTCのままで良ければ↑行は削除）
+    # === ここまで追記 ===
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,13 @@ module KouyouseiChecker
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 8.0
 
+       # === ここから追記（ISSUE #1 日本語化 & タイムゾーン）===
+    config.i18n.default_locale = :ja
+    config.i18n.available_locales = [:ja, :en]  # 必須ではないが明示しておくと安心
+    config.time_zone = 'Tokyo'
+    config.active_record.default_timezone = :local  # DBの時刻もJSTにしたい場合
+       # （UTCのままで良ければ↑行は削除）
+       # === ここまで追記 ===
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,5 @@
+ja:
+  hello: "こんにちは"
+  time:
+    formats:
+      default: "%Y/%m/%d %H:%M"


### PR DESCRIPTION
## ✅ 対応内容
- Rails プロジェクトの初期設定
- `config/application.rb` に以下を追加
  - 日本語ロケール (`config.i18n.default_locale = :ja`)
  - 利用可能ロケールの指定 (`[:ja, :en]`)
  - タイムゾーン (`config.time_zone = 'Tokyo'`)
  - DB保存時刻をローカルに (`config.active_record.default_timezone = :local`)
- `config/locales/ja.yml` を新規作成

## 🔍 動作確認
- `bin/rails c`  
  - `I18n.locale # => :ja`  
  - `Time.zone.name # => "Tokyo"`
- `bin/rails s` で起動確認  
  - `http://localhost:3000` にアクセス → Rails起動を確認

## 📂 変更ファイル
- `config/application.rb`
- `config/locales/ja.yml`

## 📌 補足
- `bundle install` 済み  
- Rails 8.0 系で動作確認済み

---

Closes #1
