### PR TITLE
Issue #3: 設問データを seeds.rb に定義（IDリセット・診断結果含む）

### DIFF
--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -1,0 +1,7 @@
+# app/models/answer.rb
+class Answer < ApplicationRecord
+  belongs_to :question
+  belongs_to :option
+
+  validates :session_id, presence: true
+end

--- a/app/models/option.rb
+++ b/app/models/option.rb
@@ -1,0 +1,8 @@
+# app/models/option.rb
+class Option < ApplicationRecord
+  belongs_to :question
+  has_many :answers, dependent: :restrict_with_exception
+
+  validates :label, presence: true
+  validates :score, presence: true, numericality: { only_integer: true }
+end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,0 +1,8 @@
+# app/models/question.rb
+class Question < ApplicationRecord
+    has_many :options, dependent: :destroy
+    has_many :answers, dependent: :destroy
+  
+    validates :content, presence: true, length: { maximum: 2000 }
+  end
+  

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -2,7 +2,6 @@
 class Question < ApplicationRecord
     has_many :options, dependent: :destroy
     has_many :answers, dependent: :destroy
-  
+
     validates :content, presence: true, length: { maximum: 2000 }
-  end
-  
+end

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -1,0 +1,17 @@
+# app/models/result.rb
+class Result < ApplicationRecord
+    # 単独保持（他モデルに紐づけない）
+    validates :min_score, :max_score, presence: true, numericality: { only_integer: true }
+    validates :level, :comment, presence: true
+  
+    validate :score_range_order
+  
+    private
+  
+    def score_range_order
+      if min_score && max_score && max_score < min_score
+        errors.add(:max_score, 'must be greater than or equal to min_score')
+      end
+    end
+  end
+  

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -3,15 +3,14 @@ class Result < ApplicationRecord
     # 単独保持（他モデルに紐づけない）
     validates :min_score, :max_score, presence: true, numericality: { only_integer: true }
     validates :level, :comment, presence: true
-  
+
     validate :score_range_order
-  
+
     private
-  
+
     def score_range_order
       if min_score && max_score && max_score < min_score
-        errors.add(:max_score, 'must be greater than or equal to min_score')
+        errors.add(:max_score, "must be greater than or equal to min_score")
       end
     end
-  end
-  
+end

--- a/db/migrate/20250903061114_create_questions.rb
+++ b/db/migrate/20250903061114_create_questions.rb
@@ -1,0 +1,9 @@
+class CreateQuestions < ActiveRecord::Migration[8.0]
+  def change
+    create_table :questions do |t|
+      t.text :content, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250903061123_create_options.rb
+++ b/db/migrate/20250903061123_create_options.rb
@@ -1,0 +1,10 @@
+class CreateOptions < ActiveRecord::Migration[8.0]
+  def change
+    create_table :options do |t|
+      t.string     :label,    null: false
+      t.integer    :score,    null: false, default: 0
+      t.references :question, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250903061129_create_results.rb
+++ b/db/migrate/20250903061129_create_results.rb
@@ -1,0 +1,11 @@
+class CreateResults < ActiveRecord::Migration[8.0]
+  def change
+    create_table :results do |t|
+      t.integer :min_score, null: false
+      t.integer :max_score, null: false
+      t.string  :level,     null: false
+      t.text    :comment,   null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250903061134_create_answers.rb
+++ b/db/migrate/20250903061134_create_answers.rb
@@ -1,0 +1,12 @@
+class CreateAnswers < ActiveRecord::Migration[8.0]
+  def change
+    create_table :answers do |t|
+      t.string :session_id
+      t.references :question, null: false, foreign_key: true
+      t.references :option, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :answers, :session_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,5 +10,43 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 0) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_03_061134) do
+  create_table "answers", charset: "utf8mb3", force: :cascade do |t|
+    t.string "session_id"
+    t.bigint "question_id", null: false
+    t.bigint "option_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["option_id"], name: "index_answers_on_option_id"
+    t.index ["question_id"], name: "index_answers_on_question_id"
+    t.index ["session_id"], name: "index_answers_on_session_id"
+  end
+
+  create_table "options", charset: "utf8mb3", force: :cascade do |t|
+    t.string "label", null: false
+    t.integer "score", default: 0, null: false
+    t.bigint "question_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["question_id"], name: "index_options_on_question_id"
+  end
+
+  create_table "questions", charset: "utf8mb3", force: :cascade do |t|
+    t.text "content", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "results", charset: "utf8mb3", force: :cascade do |t|
+    t.integer "min_score", null: false
+    t.integer "max_score", null: false
+    t.string "level", null: false
+    t.text "comment", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_foreign_key "answers", "options"
+  add_foreign_key "answers", "questions"
+  add_foreign_key "options", "questions"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,9 +1,77 @@
-# This file should ensure the existence of records required to run the application in every environment (production,
-# development, test). The code here should be idempotent so that it can be executed at any point in every environment.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Example:
-#
-#   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
-#     MovieGenre.find_or_create_by!(name: genre_name)
-#   end
+# db/seeds.rb
+# frozen_string_literal: true
+
+# ===== 初期化（FK整合性を保ちつつ高速削除 & PKリセット）=====
+ActiveRecord::Base.transaction do
+    # 子 → 親 の順で削除
+    Answer.delete_all
+    Option.delete_all
+    Question.delete_all
+    Result.delete_all
+
+    tables  = %w[answers options questions results]
+    adapter = ApplicationRecord.connection.adapter_name.downcase
+
+    if adapter.include?("mysql")
+      # MySQL: AUTO_INCREMENT をリセット
+      ApplicationRecord.connection.execute("SET FOREIGN_KEY_CHECKS = 0")
+      tables.each do |t|
+        ApplicationRecord.connection.execute("ALTER TABLE #{t} AUTO_INCREMENT = 1")
+      end
+      ApplicationRecord.connection.execute("SET FOREIGN_KEY_CHECKS = 1")
+    elsif adapter.include?("postgresql") || adapter.include?("sqlite")
+      # PostgreSQL / SQLite: 既存のヘルパを使用
+      tables.each do |t|
+        ApplicationRecord.connection.reset_pk_sequence!(t)
+      end
+    else
+      Rails.logger.warn("PK reset unsupported adapter: #{adapter}")
+    end
+  end
+
+  puts "== 🔧 Reset finished =="
+
+  # ===== 設問（10問） =====
+  questions = [
+    "新しいことに挑戦するのが好きだ",
+    "変化のある環境にワクワクする",
+    "楽しいことを見つけるのが得意だ",
+    "周りを巻き込んで盛り上げることがある",
+    "失敗しても前向きに切り替えられる",
+    "好きなことにはとことん没頭する",
+    "アイデアがどんどん湧いてくる",
+    "自分の気分で周りの空気が変わると感じる",
+    "常に面白さや刺激を探している",
+    "自分の気持ちを表現するのが得意だ"
+  ]
+
+  # ===== 選択肢（5段階・スコア付き）=====
+  options = [
+    { label: "とても当てはまる", score: 5 },
+    { label: "当てはまる", score: 4 },
+    { label: "どちらともいえない", score: 3 },
+    { label: "あまり当てはまらない", score: 2 },
+    { label: "まったく当てはまらない", score: 1 }
+  ]
+
+  # ===== 作成（Question と Option）=====
+  questions.each do |content|
+    q = Question.create!(content: content)
+    options.each do |opt|
+      Option.create!(question: q, label: opt[:label], score: opt[:score])
+    end
+  end
+
+  # ===== 診断結果（A〜D）=====
+  results = [
+    { min_score: 45, max_score: 50, level: "A", comment: "あなたは超・高揚性タイプ！楽しさで人を動かすリーダーです。" },
+    { min_score: 35, max_score: 44, level: "B", comment: "あなたは高揚性が高いタイプ。日々を前向きに楽しめていますね。" },
+    { min_score: 25, max_score: 34, level: "C", comment: "高揚性は普通レベル。もっとワクワクに目を向けてみましょう！" },
+    { min_score: 10, max_score: 24, level: "D", comment: "今は少し控えめかも？小さな楽しさから再起動を始めてみて！" }
+  ]
+
+  results.each do |r|
+    Result.create!(r)
+  end
+
+  puts "🌱 Seed完了！設問と診断結果を登録しました。"

--- a/test/fixtures/answers.yml
+++ b/test/fixtures/answers.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  session_id: MyString
+  question: one
+  option: one
+
+two:
+  session_id: MyString
+  question: two
+  option: two

--- a/test/fixtures/options.yml
+++ b/test/fixtures/options.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  label: MyString
+  score: 1
+  question: one
+
+two:
+  label: MyString
+  score: 1
+  question: two

--- a/test/fixtures/questions.yml
+++ b/test/fixtures/questions.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  content: MyText
+
+two:
+  content: MyText

--- a/test/fixtures/results.yml
+++ b/test/fixtures/results.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  min_score: 1
+  max_score: 1
+  level: MyString
+  comment: MyText
+
+two:
+  min_score: 1
+  max_score: 1
+  level: MyString
+  comment: MyText

--- a/test/models/answer_test.rb
+++ b/test/models/answer_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class AnswerTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/option_test.rb
+++ b/test/models/option_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class OptionTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/question_test.rb
+++ b/test/models/question_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class QuestionTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/result_test.rb
+++ b/test/models/result_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ResultTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## ✅ 対応内容
- `db/seeds.rb` を作成/更新
  - Question（10問）を登録
  - 各 Question に 5 段階の Option（スコア付き）を紐づけて登録（合計50件）
  - Result（A〜D）の4パターンを登録
- 既存データの初期化と **PKリセット** を実装
  - MySQL: `AUTO_INCREMENT` をリセット
  - PostgreSQL/SQLite: `reset_pk_sequence!` を使用
- 実行後に `"🌱 Seed完了！設問と診断結果を登録しました。"` を出力

## 🔍 動作確認
- `bin/rails db:seed` を実行し成功
- Rails コンソールで確認
  - `Question.count == 10`
  - `Option.count == 50`
  - `Result.count == 4`

## 📂 変更ファイル
- `db/seeds.rb`

---

Closes #3
