### PR TITLE
Issue#5 スコア集計と診断結果の表示機能を実装 

### DIFF
--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class ResultsController < ApplicationController
+  def show
+    # URLパラメータからセッションIDを取得
+    session_id = params[:id]
+    
+    # 該当セッションの回答を取得
+    answers = Answer.where(session_id: session_id).includes(:option)
+    
+    # 回答が存在しない場合は診断画面へリダイレクト
+    if answers.empty?
+      return redirect_to questions_path, alert: "診断結果が見つかりませんでした。"
+    end
+    
+    # 合計スコアを算出
+    @total_score = answers.joins(:option).sum("options.score")
+    
+    # 診断結果を取得（範囲一致）
+    @result = Result.where("min_score <= ? AND max_score >= ?", @total_score, @total_score).first
+    
+    # 結果が見つからない場合のエラーハンドリング
+    unless @result
+      return redirect_to questions_path, alert: "診断結果の判定に失敗しました。"
+    end
+    
+    @session_id = session_id
+  end
+end

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -4,26 +4,26 @@ class ResultsController < ApplicationController
   def show
     # URLパラメータからセッションIDを取得
     session_id = params[:id]
-    
+
     # 該当セッションの回答を取得
     answers = Answer.where(session_id: session_id).includes(:option)
-    
+
     # 回答が存在しない場合は診断画面へリダイレクト
     if answers.empty?
       return redirect_to questions_path, alert: "診断結果が見つかりませんでした。"
     end
-    
+
     # 合計スコアを算出
     @total_score = answers.joins(:option).sum("options.score")
-    
+
     # 診断結果を取得（範囲一致）
     @result = Result.where("min_score <= ? AND max_score >= ?", @total_score, @total_score).first
-    
+
     # 結果が見つからない場合のエラーハンドリング
     unless @result
       return redirect_to questions_path, alert: "診断結果の判定に失敗しました。"
     end
-    
+
     @session_id = session_id
   end
 end

--- a/app/views/results/show.html.erb
+++ b/app/views/results/show.html.erb
@@ -1,0 +1,42 @@
+<div class="container mx-auto px-4 py-8 max-w-2xl">
+  <div class="bg-white rounded-lg shadow-lg p-8">
+    <h1 class="text-3xl font-bold text-center mb-6 text-gray-800">診断結果</h1>
+    
+    <div class="mb-8">
+      <div class="text-center mb-4">
+        <p class="text-lg text-gray-600 mb-2">あなたの合計スコア</p>
+        <div class="text-5xl font-bold text-blue-600"><%= @total_score %>点</div>
+      </div>
+      
+      <div class="mt-6 p-4 bg-blue-50 rounded-lg">
+        <p class="text-sm text-gray-600 text-center">
+          スコア範囲: <%= @result.min_score %> - <%= @result.max_score %>点
+        </p>
+      </div>
+    </div>
+    
+    <div class="mb-8">
+      <h2 class="text-2xl font-semibold mb-4 text-gray-800">診断レベル</h2>
+      <div class="p-6 bg-gradient-to-r from-blue-500 to-purple-600 rounded-lg text-white">
+        <p class="text-3xl font-bold text-center"><%= @result.level %></p>
+      </div>
+    </div>
+    
+    <div class="mb-8">
+      <h2 class="text-xl font-semibold mb-4 text-gray-800">コメント</h2>
+      <div class="p-6 bg-gray-50 rounded-lg">
+        <p class="text-gray-700 leading-relaxed"><%= @result.comment %></p>
+      </div>
+    </div>
+    
+    <div class="mt-8 text-center">
+      <%= link_to "もう一度診断する", questions_path, class: "inline-block px-6 py-3 bg-blue-600 text-white font-semibold rounded-lg hover:bg-blue-700 transition duration-200" %>
+    </div>
+    
+    <div class="mt-6 text-center">
+      <p class="text-sm text-gray-500">
+        診断ID: <%= @session_id %>
+      </p>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
       post :submit # /questions/submit にPOST
     end
   end
-  
+
   # 診断結果表示
   resources :results, only: [ :show ], param: :id
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,4 +5,7 @@ Rails.application.routes.draw do
       post :submit # /questions/submit にPOST
     end
   end
+  
+  # 診断結果表示
+  resources :results, only: [ :show ], param: :id
 end


### PR DESCRIPTION
## 概要
  診断の回答を保存し、スコア集計後に専用の結果ページ
  `/results/:id`
  で診断結果を表示する機能を実装しました。

  ## 変更内容

  ### 🎯 主な機能
  - 回答データをデータベースに保存
  - 合計スコアを算出して該当する診断結果を抽出
  - `/results/:id` ページで診断結果を表示

  ### 📝 実装詳細

  #### 1. ResultsController の作成
  - セッションIDを用いて回答データを取得
  - 合計スコアを集計
  - スコア範囲に基づいて適切な診断結果を抽出

  #### 2. QuestionsController#submit の改修
  - UUID形式のセッションIDを生成
  - 各回答をAnswerテーブルに保存
  - 診断完了後は `/results/:id` へリダイレクト

  #### 3. 結果表示ビューの作成
  - 診断スコア、レベル、コメントを表示
  - Tailwind CSSによるレスポンシブデザイン
  - 再診断用のリンクを配置

  #### 4. ルーティングの追加
  - `resources :results, only: [:show]` を追加

  ## 関連Issue
  Closes #5

  ## テスト確認事項
  - [ ] 全ての質問に回答後、結果ページへ正常にリダイレ
  クトされること
  - [ ] 結果ページでスコア、レベル、コメントが正しく表
  示されること
  - [ ]
  同一セッションIDで結果ページに再アクセス可能なこと
  - [ ] 存在しないセッションIDでアクセスした場合、適切
  にエラーハンドリングされること